### PR TITLE
Style-enforcement fix

### DIFF
--- a/.github/workflows/style-enforcement.yml
+++ b/.github/workflows/style-enforcement.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: DoozyX/clang-format-lint-action@v0.9
       with:
-        source: './src ./include ./test ./hardware/*/src ./hardware/*/include'
+        source: './src ./include ./test ./hardware'
         exclude: ''
         extensions: 'h,cpp,c'
         clangFormatVersion: 11


### PR DESCRIPTION
* Dropped style enforcement action by a version; apparently there's a regression bug in 0.10.
* Added hardware libraries to the files to be checked.