### PR TITLE
Fix to RST.

### DIFF
--- a/src/branch_opcodes.c
+++ b/src/branch_opcodes.c
@@ -163,7 +163,7 @@ int rst(const uint8_t* opcode, struct cpu_state* cpu)
 
 	// Push PC onto the stack.
 	cpu->sp -= 2;
-	*((uint16_t*) cpu->memory + cpu->sp) = cpu->pc;
+	*((uint16_t*) (cpu->memory + cpu->sp)) = cpu->pc;
 	// RST jumps to the address signified in bits 3, 4, and 5 of the opcode,
 	// multiplied by eight.  As it happens, bit 3 is already the 8s place,
 	// so we can just filter out all the other bits and assign that

--- a/test/branch_opcode_tests.cpp
+++ b/test/branch_opcode_tests.cpp
@@ -270,7 +270,7 @@ TEST(RST, All)
 	// It should also decrement SP by two and push PC
 	// onto the stack.
 	EXPECT_EQ(cpu.sp, 0x0ffe);
-	EXPECT_EQ(*((uint16_t*) cpu.memory + cpu.sp), 0xfff0);
+	EXPECT_EQ(*((uint16_t*) (cpu.memory + cpu.sp)), 0xfff0);
 
 	// RST 0x0008
 	opcode = 0xcf;
@@ -278,7 +278,7 @@ TEST(RST, All)
 	rst(&opcode, &cpu);
 	EXPECT_EQ(cpu.pc, 0x0008);
 	EXPECT_EQ(cpu.sp, 0x0ffc);
-	EXPECT_EQ(*((uint16_t*) cpu.memory + cpu.sp), 0x0000);
+	EXPECT_EQ(*((uint16_t*) (cpu.memory + cpu.sp)), 0x0000);
 
 	// RST 0x0038
 	opcode = 0xff;
@@ -286,5 +286,5 @@ TEST(RST, All)
 	rst(&opcode, &cpu);
 	EXPECT_EQ(cpu.pc, 0x0038);
 	EXPECT_EQ(cpu.sp, 0x0ffa);
-	EXPECT_EQ(*((uint16_t*) cpu.memory + cpu.sp), 0x0008);
+	EXPECT_EQ(*((uint16_t*) (cpu.memory + cpu.sp)), 0x0008);
 }


### PR DESCRIPTION
This fixes a simple order-of-operations issue in RST that was causing incorrect values to be pushed onto the stack.