### PR TITLE
Flip coin logic

### DIFF
--- a/hardware/si/src/hw_funcs.c
+++ b/hardware/si/src/hw_funcs.c
@@ -51,7 +51,6 @@ int hw_in(const uint8_t* opcode, struct cpu_state* cpu)
 			 | rstruct->dip6 << 3 | rstruct->p2_shoot << 4
 			 | rstruct->p2_left << 5 | rstruct->p2_right << 6
 			 | rstruct->dip7 << 7;
-		rstruct->tilt = 0;
 		pthread_mutex_unlock(tstruct->keystate_lock);
 		break;
 	case 3:

--- a/hardware/si/src/hw_funcs.c
+++ b/hardware/si/src/hw_funcs.c
@@ -43,7 +43,6 @@ int hw_in(const uint8_t* opcode, struct cpu_state* cpu)
 			 | rstruct->p1_start << 2 | 1 << 3
 			 | rstruct->p1_shoot << 4 | rstruct->p1_left << 5
 			 | rstruct->p1_right << 6 | 0 << 7;
-		rstruct->coin = 0;
 		pthread_mutex_unlock(tstruct->keystate_lock);
 		break;
 	case 2:
@@ -119,6 +118,7 @@ void* hw_init_struct(struct system_resources* res)
 	rstruct->dip5 = 1;
 	rstruct->dip6 = 1;
 	rstruct->dip7 = 1;
+	rstruct->coin = 1;
 
 	// Call the constructor for the taito library's struct.
 	struct taito_struct* tstruct = create_taito_struct(res, rstruct);

--- a/hardware/si/src/update_keystates.cpp
+++ b/hardware/si/src/update_keystates.cpp
@@ -13,7 +13,7 @@ void update_keystates(void* t_struct, SDL_Event* event)
 		switch (event->key.keysym.scancode)
 		{
 		case SDL_SCANCODE_R: *(tStruct->reset_flag) = 1; break;
-		case SDL_SCANCODE_C: rStruct->coin = 1; break;
+		case SDL_SCANCODE_C: rStruct->coin = 0; break;
 		case SDL_SCANCODE_S: rStruct->p1_start = 1; break;
 		case SDL_SCANCODE_DOWN: rStruct->p2_start = 1; break;
 		case SDL_SCANCODE_LEFT: rStruct->p2_left = 1; break;
@@ -42,7 +42,7 @@ void update_keystates(void* t_struct, SDL_Event* event)
 		switch (event->key.keysym.scancode)
 		{
 			// Keystate toggles - cleared on keyup
-		case SDL_SCANCODE_C: rStruct->coin = 0; break;
+		case SDL_SCANCODE_C: rStruct->coin = 1; break;
 		case SDL_SCANCODE_T: rStruct->tilt = 0; break;
 		case SDL_SCANCODE_S: rStruct->p1_start = 0; break;
 		case SDL_SCANCODE_DOWN: rStruct->p2_start = 0; break;


### PR DESCRIPTION
* Reverses the logic of the coin slot: button down is now 0 and button up is now 1.

* Removes clear-on-read from tilt and coin.  Both are now cleared (to 0 and 1 respectively) on key-up.