### PR TITLE
Changed the build RPATH to $ORIGIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set(FlagSettings "-Wall" "-Werror" "-Wextra"
 	"$<$<CONFIG:DEBUG>:-DVERBOSE -DDEBUG>"
 )
 
+set (CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH}:$ORIGIN})
+
 OPTION(UNTHROTTLE "Unthrottle emulated CPU speed" OFF)
 CMAKE_DEPENDENT_OPTION(BENCHMARKING "Turn on CPU emulation speed benchmarking output" OFF 
 	"NOT UNTHROTTLE" OFF)


### PR DESCRIPTION
This adjusts the RPATH specified in the CMake to be relative rather than absolute: without this, trying to zip and relocate the built program will result in `si` being unable to find `taito`.